### PR TITLE
revert: abort dispatch if config file disappeared

### DIFF
--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -18,15 +18,6 @@ else
     script_dir=$SCRIPT_DIR/up.d
 fi
 
-# When live migrating from a hypervisor, the config file for the vm is moved 
-# several times, then disappears.
-# We wait one second to check that this is not happening here.
-wait 1
-if [ ! -f $file ] ; then
-    logger -t $LOGGER_TAG "Dispatch: file $file disappeared, exiting"
-    exit
-fi
-
 for script in $script_dir/*; do
     logger -t $LOGGER_TAG "Dispatch: launching $script $file"
     [ -x $script ] && $script $file


### PR DESCRIPTION
Reverting because previous commit would have the script exit when it was launched by a MOVED_TO action (file disappeared from folder), so `failoverip-down` script would never run.

Sorry about this mistake. 