### PR TITLE
fix: abort dispatch if config file disappeared

### DIFF
--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -16,15 +16,14 @@ elif grep -q 'lock: migrate' "$file"; then
     exit
 else
     script_dir=$SCRIPT_DIR/up.d
-fi
-
-# When live migrating from a hypervisor, the config file for the vm is moved 
-# several times, then disappears.
-# We wait one second to check that this is not happening here.
-wait 1
-if [ ! -f $file ] ; then
-    logger -t $LOGGER_TAG "Dispatch: file $file disappeared, exiting"
-    exit
+    # When live migrating from a hypervisor, the config file for the vm is moved 
+    # several times, then disappears.
+    # We wait one second to check that this is not happening here.
+    wait 1
+    if [ ! -f $file ] ; then
+        logger -t $LOGGER_TAG "Dispatch: file $file disappeared, exiting !"
+        exit
+    fi
 fi
 
 for script in $script_dir/*; do


### PR DESCRIPTION
Previous commit would have the script exit when it was launched by a MOVED_TO action (file disappeared from folder), so failoverip-down script would never run.

This move fixes the logic behind this. Sorry about this mistake.