### PR TITLE
Fixes for script repeatedly trying to move IP already on target server

### DIFF
--- a/scripts/dispatch
+++ b/scripts/dispatch
@@ -4,6 +4,13 @@
 action=$1
 file=$2
 
+if [[ $(basename $file) = sed* ]]
+then
+    # If file name starts with "sed", it is a temporary file created by sed command
+    # from the vm-public-ip script, ignore the file
+    exit
+fi
+
 logger -t $LOGGER_TAG "Dispatch: detected action $1 on file $2"
 
 if [ "$action" = "MOVED_FROM" ]; then

--- a/scripts/vm-public-ip
+++ b/scripts/vm-public-ip
@@ -12,8 +12,12 @@ update_ips() {
         [ -n "$ips" ] && echo $1: $ips
     else
         file=$RESOURCE_DIR/$id.conf
-        [ -f $file ] && sed -i '/^ip/d' $file
-        [ -n "$ips" ] && echo ip $ips >> $file
+        # Only alter the file if we are really going to change its contents
+        if [ "$(cat $file)" != "ip $ips" ]
+        then
+            [ -f $file ] && sed -i '/^ip/d' $file
+            [ -n "$ips" ] && echo ip $ips >> $file
+        fi
     fi
 }
 


### PR DESCRIPTION
Some sanitized logs from actions repeated every hour, before applying this patch :

```
Feb 10 11:00:10 server1 pve-migration-monitor[4077231]: Dispatch: detected action MOVED_FROM on file /etc/pve/failoverip//sed1K1zwk
Feb 10 11:00:10 server1 pve-migration-monitor[4077236]: Dispatch: launching /etc/pve-migration-monitor/down.d/10failoverip /etc/pve/failoverip//sed1K1zwk
Feb 10 11:00:10 server1 pve-migration-monitor[4077240]: Dispatch: detected action MOVED_TO on file /etc/pve/failoverip//106.conf
Feb 10 11:00:10 server1 pve-migration-monitor[4077242]: Dispatch: launching /etc/pve-migration-monitor/up.d/10failoverip /etc/pve/failoverip//106.conf
Feb 10 11:00:10 server1 pve-migration-monitor[4077251]: Host 106.conf migrated here. Launch script to move IP1 to IP-PVE
Feb 10 11:00:11 server1 pve-migration-monitor[4077260]: Migrated IP1 to IP-PVE
Feb 10 11:00:11 server1 pve-migration-monitor[4077261]: Host 106.conf migrated here. Bring route up for IP1 in vmbr0
Feb 10 11:00:12 server1 pve-migration-monitor[4077271]: Dispatch: detected action MOVED_FROM on file /etc/pve/failoverip//seda6JaAf
Feb 10 11:00:12 server1 pve-migration-monitor[4077276]: Dispatch: launching /etc/pve-migration-monitor/down.d/10failoverip /etc/pve/failoverip//seda6JaAf
Feb 10 11:00:12 server1 pve-migration-monitor[4077280]: Dispatch: detected action MOVED_TO on file /etc/pve/failoverip//107.conf
Feb 10 11:00:12 server1 pve-migration-monitor[4077282]: Dispatch: launching /etc/pve-migration-monitor/up.d/10failoverip /etc/pve/failoverip//107.conf
Feb 10 11:00:12 server1 pve-migration-monitor[4077291]: Host 107.conf migrated here. Launch script to move IP2 to IP-PVE
Feb 10 11:00:16 server1 pve-migration-monitor[4077335]: Migrated IP2 to IP-PVE
```
